### PR TITLE
Fix: Windowsでもビルドが通るように修正・Update: bbsmenuのURL関連の変更

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -80,7 +80,11 @@ def coffee(src, output)
     src = src.join(" ")
   end
 
-  sh "cat #{src} | node_modules/.bin/coffee -cbs > #{output}"
+  if RUBY_PLATFORM.include?("darwin") || RUBY_PLATFORM.include?("linux")
+    sh "cat #{src} | node_modules/.bin/coffee -cbs > #{output}"
+  else
+    sh "cat #{src} | \"node_modules/.bin/coffee\" -cbs > #{output}"
+  end
 end
 
 def typescript(src, output)

--- a/src/view/config.coffee
+++ b/src/view/config.coffee
@@ -267,4 +267,14 @@ app.boot "/view/config.html", ["cache", "bbsmenu"], (Cache, BBSMenu) ->
     app.config.set("theme_id", if @checked then "none" else "default")
     return
 
+  # bbsmenu設定
+  do ->
+    if $view.find(".direct.bbsmenu").val() is ""
+      app.config.del("bbsmenu")
+  
+  $(".direct.bbsmenu").change ->
+    if $view.find(".direct.bbsmenu").val() isnt ""
+      $(".bbsmenu_reload").trigger("click")
+    return
+
   return


### PR DESCRIPTION
Fix: Windowsでもビルドが通るように修正6
・d5c7508 (joinオプションの修正) で発生したWindowsでビルドできないエラーを修正

Update: bbsmenuのURLを変更した際に板一覧を自動更新する/空欄のとき、既定URLを復活させる
・bbsmenuのURLを変更した際に自動的に板一覧を更新する
・bbsmenuのURLが空欄のとき、既定URLを復活させる

お願いします