### PR TITLE
Update: スレッド名に自動付加される「[転載禁止]」等を取り除く

### DIFF
--- a/src/core/Thread.coffee
+++ b/src/core/Thread.coffee
@@ -314,6 +314,7 @@ class app.Thread
 
       if title
         thread.title = app.util.decode_char_reference(title[1])
+        thread.title = thread.title.replace(/ ?(?:\[転載禁止\]|(?:\(c\)|©|�|&copy;)2ch\.net) ?/g,"")
       else if regRes
         thread.res.push
           name: regRes[2]


### PR DESCRIPTION
[転載禁止]©2ch.netなどやそれによるスレッドのミスを取り除くように。

よろしくお願いします。