### PR TITLE
Update: スレッド名に自動付加される「[転載禁止]」等を取り除く2

### DIFF
--- a/src/core/Thread.coffee
+++ b/src/core/Thread.coffee
@@ -314,7 +314,9 @@ class app.Thread
 
       if title
         thread.title = app.util.decode_char_reference(title[1])
-        thread.title = thread.title.replace(/ ?(?:\[転載禁止\]|(?:\(c\)|©|�|&copy;)2ch\.net) ?/g,"")
+        title2 = thread.title.replace(/ ?(?:\[転載禁止\]|(?:\(c\)|©|�|&copy;)2ch\.net) ?/g,"")
+        if title2 isnt ""
+          thread.title = title2
       else if regRes
         thread.res.push
           name: regRes[2]


### PR DESCRIPTION
スレッド名が空白になるのを回避

とりあえず、空白チェックで回避するようにしました

よろしくお願いします