### PR TITLE
Fix: 次スレ検索修正 & Update: ブックマークでdat落ちを表示しない+2ch.scでscだけを表示する

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -261,6 +261,7 @@ module app {
       popup_trigger: "click",
       theme_id: "default",
       user_css: "",
+      bookmark_show_dat: "on",
       format_2chnet: "html",
       button_change_netsc_newtab: "off",
       bbsmenu: "http://kita.jikkyo.org/cbm/cbm.cgi/20.p0.m0.jb.vs.op.sc.nb.bb/-all/bbsmenu.html"

--- a/src/core/Board.coffee
+++ b/src/core/Board.coffee
@@ -221,6 +221,8 @@ class app.Board
     board = []
     while (reg_res = reg.exec(text))
       title = app.util.decode_char_reference(reg_res[2])
+      if tmp[2] is "2ch.net"
+        title = title.replace(/ ?(?:\[転載禁止\]|(?:\(c\)|©|�|&copy;|&#169;)2ch\.net) ?/g,"")
 
       continue if not do (title, ngWords) ->
         for ngWord in ngWords

--- a/src/core/Thread.coffee
+++ b/src/core/Thread.coffee
@@ -314,7 +314,7 @@ class app.Thread
 
       if title
         thread.title = app.util.decode_char_reference(title[1])
-        title2 = thread.title.replace(/ ?(?:\[転載禁止\]|(?:\(c\)|©|�|&copy;)2ch\.net) ?/g,"")
+        title2 = thread.title.replace(/ ?(?:\[転載禁止\]|(?:\(c\)|©|�|&copy;|&#169;)2ch\.net) ?/g,"")
         if title2 isnt ""
           thread.title = title2
       else if regRes

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -18,7 +18,7 @@
     "notifications",
     "webRequest",
     "webRequestBlocking",
-    "http://*/*"
+    "http://*/"
   ],
   "app" : {
     "launch" : {

--- a/src/ui/ThreadList.coffee
+++ b/src/ui/ThreadList.coffee
@@ -298,6 +298,9 @@ class UI.ThreadList
       trClassName = "open_in_rcrx"
       if item.expired
         trClassName += " expired"
+      
+      if app.escape_html(item.title).substr(0,1) isnt "★"
+        trClassName += " sc"
 
       tmpHTML = " data-href=\"#{app.escape_html(item.url)}\""
       tmpHTML += " data-title=\"#{app.escape_html(item.title)}\""

--- a/src/view/board.coffee
+++ b/src/view/board.coffee
@@ -107,4 +107,13 @@ app.boot "/view/board.html", ["board_title_solver"], (BoardTitleSolver) ->
     load()
     return
   load()
+  
+  if /http:\/\/\w+\.2ch\.sc\/\w+\/(.*?)/.exec(url)
+    $view.find(".button_only_sc").on "click", ->
+      $sc = $view.find(".sc")
+      if $sc.css("display") isnt "none" then $sc.css("display", "none") else $sc.css("display", "")
+      return
+   else
+     $view.find(".button_only_sc").remove()
+  
   return

--- a/src/view/board.haml
+++ b/src/view/board.haml
@@ -26,6 +26,7 @@
         %ul
           %li.button_link
             %a(target="_blank") Chromeで直接開く
+          %li.button_only_sc scのスレだけを表示する/両方表示する
       %select.sort_item_selector
         %option(label="標準" data-sort_order="asc" data-sort_type="num") data-thread_number
         %option(label="ブックマーク") 0

--- a/src/view/bookmark.coffee
+++ b/src/view/bookmark.coffee
@@ -91,6 +91,12 @@ app.boot "/view/bookmark.html", ->
           fn()
           break
 
+      #dat落ちを表示/非表示
+      if app.config.get("bookmark_show_dat") is "off"
+        $view.find(".expired").css("display", "none")
+      else
+        $view.find(".expired").css("display", "")
+      
       #ステータス表示更新
       $loading_overlay.find(".success").text(count.success)
       $loading_overlay.find(".error").text(count.error)
@@ -113,6 +119,14 @@ app.boot "/view/bookmark.html", ->
 
   app.message.send("request_update_read_state", {})
   $table.table_sort("update")
+
+  $view.find(".button_toggle_dat").on "click", ->
+    $expired = $view.find(".expired")
+    if $expired.css("display") isnt "none"
+      $expired.css("display", "none")
+    else
+      $expired.css("display", "")
+    return
 
   $view.trigger("view_loaded")
   return

--- a/src/view/bookmark.haml
+++ b/src/view/bookmark.haml
@@ -24,6 +24,7 @@
         %ul
           %li.button_link
             %a(target="_blank") ブックマークマネージャを開く
+          %li.button_toggle_dat dat落ちのスレッドを表示する/しない
       %select.sort_item_selector
         %option(label="タイトル") 0
         %option(label="レス数") 1

--- a/src/view/config.haml
+++ b/src/view/config.haml
@@ -182,6 +182,9 @@
             )
             %input.direct.bbsmenu(type="text" name="bbsmenu")
             %button.bbsmenu_reset(type="button") リセット
+          %br
+          %label
+            %input.direct(type="checkbox" name="bookmark_show_dat") ブックマークのdat落ちスレを常に表示する/しない
 
       %section
         %h2 2ch.netのスレッド読み込み形式

--- a/src/view/module.coffee
+++ b/src/view/module.coffee
@@ -616,6 +616,17 @@ class app.view.TabContentView extends app.view.PaneContentView
           url: url.replace(from, to),
           new_tab: app.config.get("button_change_netsc_newtab") is "on"
         }
-      return
+        return
     else
       @$element.find(".button_change_netsc").remove()
+    
+    #2ch.scでscの投稿だけ表示
+    if /http:\/\/\w+\.2ch\.sc\/\w+\/(.*?)/.exec(url)
+      @$element.find(".button_only_sc").on "click", =>
+        @$element.find("article").each ->
+          if $(this).attr("data-id").substr(-4,4) is ".net"
+            if $(this).css("display") isnt "none" then $(this).css("display", "none") else $(this).css("display", "")
+          return
+        return
+    else
+      @$element.find(".button_only_sc").remove()

--- a/src/view/thread.haml
+++ b/src/view/thread.haml
@@ -31,6 +31,7 @@
           %li.button_copy_url スレッドのURLをコピー
           %li.button_copy_title_and_url スレッドのタイトルとURLをコピー
           %li.button_change_netsc 2ch.net/2ch.scに切り替え
+          %li.button_only_sc scの投稿だけを表示する/両方表示する
           %li.button_tool_search_next_thread 次スレ検索
       %ul.breadcrumb
         %li


### PR DESCRIPTION
bd6812b によって次スレ検索がうまく作動していなかったので修正しました
常にdat落ちしたスレッドを表示する/しないオプション、一時的に表示する/しないボタンを追加しました
2ch.scでスレッド内のレス、板内のスレッドともにscだけを表示するボタンを追加しました

よろしくお願いします