### PR TITLE
Fix: dat落ち表示設定の動作&scのみのレスの表示時間&Update: 2ch.netの差分取得に対応

### DIFF
--- a/src/ui/ThreadContent.coffee
+++ b/src/ui/ThreadContent.coffee
@@ -293,6 +293,9 @@ class UI.ThreadContent
 
               if fixedId is @oneId
                 articleClass.push("one")
+              
+              if fixedId.substr(-4,4) is ".net"
+                articleClass.push("net")
 
               @idIndex[fixedId] = [] unless @idIndex[fixedId]?
               @idIndex[fixedId].push(resNum)

--- a/src/view/bookmark.coffee
+++ b/src/view/bookmark.coffee
@@ -90,12 +90,6 @@ app.boot "/view/bookmark.html", ->
           app.board.get(current, fn.bind(prev: current))
           fn()
           break
-
-      #dat落ちを表示/非表示
-      if app.config.get("bookmark_show_dat") is "off"
-        $view.find(".expired").css("display", "none")
-      else
-        $view.find(".expired").css("display", "")
       
       #ステータス表示更新
       $loading_overlay.find(".success").text(count.success)
@@ -116,6 +110,12 @@ app.boot "/view/bookmark.html", ->
       created_at: /\/(\d+)\/$/.exec(a.url)[1] * 1000
       expired: a.expired
   )
+
+  #dat落ちを表示/非表示
+  if app.config.get("bookmark_show_dat") is "off"
+   $view.find(".expired").css("display", "none")
+  else
+   $view.find(".expired").css("display", "")
 
   app.message.send("request_update_read_state", {})
   $table.table_sort("update")

--- a/src/view/config.haml
+++ b/src/view/config.haml
@@ -184,7 +184,7 @@
             %button.bbsmenu_reset(type="button") リセット
           %br
           %label
-            %input.direct(type="checkbox" name="bookmark_show_dat") ブックマークのdat落ちスレを常に表示する/しない
+            %input.direct(type="checkbox" name="bookmark_show_dat") ブックマークのdat落ちスレを常に表示する
 
       %section
         %h2 2ch.netのスレッド読み込み形式

--- a/src/view/module.coffee
+++ b/src/view/module.coffee
@@ -623,10 +623,8 @@ class app.view.TabContentView extends app.view.PaneContentView
     #2ch.scでscの投稿だけ表示
     if /http:\/\/\w+\.2ch\.sc\/\w+\/(.*?)/.exec(url)
       @$element.find(".button_only_sc").on "click", =>
-        @$element.find("article").each ->
-          if $(this).attr("data-id").substr(-4,4) is ".net"
-            if $(this).css("display") isnt "none" then $(this).css("display", "none") else $(this).css("display", "")
-          return
+        @$net = @$element.find(".net")
+        if @$net.css("display") isnt "none" then @$net.css("display", "none") else @$net.css("display", "")
         return
     else
       @$element.find(".button_only_sc").remove()


### PR DESCRIPTION
Fix: ブックマークでのdat落ち表示設定の動作を修正&scのみのレスの表示の時間短縮
Update: 2ch.netの差分取得に対応

よろしくお願いします